### PR TITLE
Fix custom TV rendering for new resources

### DIFF
--- a/assets/tvs/multifields/multifields.customtv.php
+++ b/assets/tvs/multifields/multifields.customtv.php
@@ -8,5 +8,5 @@ if (!defined('MODX_BASE_PATH')) {
     die('HACK???');
 }
 
-echo MultiFields\Base\Core::getInstance()
-    ->render($content['id'], $row);
+echo Multifields\Base\Core::getInstance()
+    ->render($content['id'] ?? 0, $row);


### PR DESCRIPTION
## Problem

The published custom TV renderer uses `MultiFields\Base\Core`, while Composer registers the package namespace as `Multifields\`. It also reads `$content['id']` directly, although new resources do not have an ID before their first save.

## Why

The namespace mismatch causes a fatal class-not-found error. The missing ID causes `Undefined array key "id"` warnings once per rendered language tab when creating a resource.

## What Changed

- use the Composer-registered `Multifields\Base\Core` namespace
- pass `0` to `Core::render()` until a new resource receives its ID

## Where

- `assets/tvs/multifields/multifields.customtv.php`

## Verification

- `git diff --check`
- confirmed the namespace against `composer.json` PSR-4 configuration
- confirmed the fallback against the existing `Core::render($id = 0, $row = [])` contract
- verified in the MAUP Library manager that the new-resource form renders without the previous fatal error or Tracy warnings

## Remaining Gaps

PHP CLI is unavailable in the local Windows environment, so native PHP lint was not run.