### PR TITLE
feat(iframe): add embeddable content block

### DIFF
--- a/config/constructor.php
+++ b/config/constructor.php
@@ -34,6 +34,7 @@ if (in_array($currentTemplateId, [1], true)) {
 $config['templates'] = array_merge(
     $config['templates'],
     include $path . 'richtext.php',
+    include $path . 'iframe.php',
     include $path . 'cards.php',
     include $path . 'logos.php',
     include $path . 'faq.php',

--- a/config/partials/iframe.php
+++ b/config/partials/iframe.php
@@ -1,0 +1,19 @@
+<?php return [
+    'iframe' => [
+        'title' => __('multiFields::global.iframe_block'),
+        'label' => __('multiFields::global.iframe_block'),
+        'icon' => svg('tabler-code')->toHtml(),
+        'type' => 'row',
+        'actions' => ['move', 'hide', 'expand', 'del'],
+        'value' => false,
+        'class' => 'col-12',
+        'items' => [
+            'url' => [
+                'title' => __('multiFields::global.iframe_url'),
+                'type' => 'text',
+                'placeholder' => 'https://...',
+                'class' => 'col-12',
+            ],
+        ],
+    ],
+];

--- a/lang/de/global.php
+++ b/lang/de/global.php
@@ -17,6 +17,8 @@ return [
     'cards_list' => 'Kartenliste',
     'image' => 'Bild',
     'richtext_block' => 'Texteditor',
+    'iframe_block' => 'Iframe',
+    'iframe_url' => 'URL zum Einbetten',
     'faq_block' => 'Fragen und Antworten',
     'faq_list' => 'Liste der Fragen und Antworten',
     'question' => 'Frage',

--- a/lang/en/global.php
+++ b/lang/en/global.php
@@ -17,6 +17,8 @@ return [
     'cards_list' => 'Cards list',
     'image' => 'Image',
     'richtext_block' => 'Text editor',
+    'iframe_block' => 'Iframe',
+    'iframe_url' => 'Embed URL',
     'faq_block' => 'Questions and answers',
     'faq_list' => 'Questions and answers list',
     'question' => 'Question',

--- a/lang/fr/global.php
+++ b/lang/fr/global.php
@@ -17,6 +17,8 @@ return [
     'cards_list' => 'Liste des cartes',
     'image' => 'Image',
     'richtext_block' => 'Editeur de texte',
+    'iframe_block' => 'Iframe',
+    'iframe_url' => 'URL a integrer',
     'faq_block' => 'Questions et reponses',
     'faq_list' => 'Liste de questions et reponses',
     'question' => 'Question',

--- a/lang/pl/global.php
+++ b/lang/pl/global.php
@@ -17,6 +17,8 @@ return [
     'cards_list' => 'Lista kart',
     'image' => 'Obraz',
     'richtext_block' => 'Edytor tekstu',
+    'iframe_block' => 'Iframe',
+    'iframe_url' => 'Adres URL do osadzenia',
     'faq_block' => 'Pytania i odpowiedzi',
     'faq_list' => 'Lista pytan i odpowiedzi',
     'question' => 'Pytanie',

--- a/lang/uk/global.php
+++ b/lang/uk/global.php
@@ -17,6 +17,8 @@ return [
     'cards_list' => 'Список карток',
     'image' => 'Зображення',
     'richtext_block' => 'Текстовий редактор',
+    'iframe_block' => 'Iframe',
+    'iframe_url' => 'Посилання для вбудовування',
     'faq_block' => 'Питання та відповіді',
     'faq_list' => 'Список питань і відповідей',
     'question' => 'Питання',

--- a/views/iframe.blade.php
+++ b/views/iframe.blade.php
@@ -1,0 +1,36 @@
+@php
+    $url = trim((string)($items['url'] ?? ''));
+    $embedUrl = '';
+
+    if (filter_var($url, FILTER_VALIDATE_URL)) {
+        $parts = parse_url($url);
+        $scheme = strtolower((string)($parts['scheme'] ?? ''));
+        $host = strtolower((string)($parts['host'] ?? ''));
+
+        if ($scheme === 'https') {
+            $embedUrl = $url;
+
+            if (in_array($host, ['docs.google.com', 'drive.google.com'], true)) {
+                $path = (string)($parts['path'] ?? '');
+
+                if (preg_match('~/d/(?:e/)?[^/]+/(?:edit|view)/?$~', $path)) {
+                    $path = preg_replace('~/(?:edit|view)/?$~', '/preview', $path);
+                    $embedUrl = 'https://' . $host . $path;
+                }
+            }
+        }
+    }
+@endphp
+
+@if($embedUrl !== '')
+    <div class="my-10">
+        <iframe
+            src="{{ $embedUrl }}"
+            title="@lang('multiFields::global.iframe_block')"
+            loading="lazy"
+            referrerpolicy="strict-origin-when-cross-origin"
+            allowfullscreen
+            style="display:block;width:100%;min-height:75vh;border:0"
+        ></iframe>
+    </div>
+@endif


### PR DESCRIPTION
## Problem

MultiFields has reusable content blocks, but it does not provide a generic way to embed externally hosted documents or other iframe-compatible resources. Project implementations therefore have to define this block themselves.

## Branch reason

The previous custom-TV rendering branch was already merged as PR #4. This feature is isolated on a new branch based on the current upstream `master`.

## Change summary

- add a reusable `iframe` constructor block with a single embed URL field
- render valid HTTPS URLs through a lazy-loaded responsive iframe
- convert Google Docs and Google Drive `edit` or `view` links to embeddable `preview` URLs
- add labels for Ukrainian, English, German, French, and Polish; Russian continues to use the Ukrainian fallback

## Landing surfaces

- `config/constructor.php`
- `config/partials/iframe.php`
- `views/iframe.blade.php`
- `lang/*/global.php`

## Verification

- PHP syntax checks passed for the constructor, iframe config, and all changed locale files on PHP 8.4
- the new Blade template compiles and its compiled PHP passes syntax validation
- `git diff --check` passed
- the package diff contains exactly eight intended files

## Remaining open items

- manager and frontend runtime smoke testing should be repeated after the package branch is installed in a consumer project
